### PR TITLE
OSDOCS-8149: hide update service link for upstream

### DIFF
--- a/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
+++ b/frontend/public/components/modals/configure-cluster-upstream-modal.tsx
@@ -15,6 +15,7 @@ import {
   getDocumentationURL,
   HandlePromiseProps,
   isManaged,
+  isUpstream,
   withHandlePromise,
 } from '../utils';
 import { useTranslation } from 'react-i18next';
@@ -61,7 +62,7 @@ export const ConfigureClusterUpstreamModal = withHandlePromise(
               'public~Select a configuration to receive updates. Updates can be configured to receive information from Red Hat or a custom update service.',
             )}
           </p>
-          {!isManaged() && (
+          {!isManaged() && !isUpstream() && (
             <p>
               <ExternalLink
                 href={updateURL}


### PR DESCRIPTION
Don't show link for upstream (OKD)
<img width="642" alt="Screenshot 2023-10-20 at 4 24 23 PM" src="https://github.com/kalexand-rh/console/assets/895728/5a93fa83-e049-40f8-b5f6-6d9b38126b53">
